### PR TITLE
Download to directories other than "mods"

### DIFF
--- a/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/ModDirectorRemoteMod.java
+++ b/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/ModDirectorRemoteMod.java
@@ -9,21 +9,31 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public abstract class ModDirectorRemoteMod {
     private final RemoteModMetadata metadata;
     private final Map<String, Object> options;
+    private final String folderName;
+    private Boolean inject;
 
-    public ModDirectorRemoteMod(RemoteModMetadata metadata, Map<String, Object> options) {
+    public ModDirectorRemoteMod(RemoteModMetadata metadata, Map<String, Object> options, String folderName, Boolean inject) {
         this.metadata = metadata;
         this.options = options == null ? Collections.emptyMap() : options;
+        this.folderName = folderName;
+        if(inject == null) {
+            this.inject = folderName == null;
+        } else {
+            this.inject = inject;
+        }
     }
 
     public abstract String remoteType();
     public abstract String offlineName();
-    public abstract String folderName();
-	public abstract int forceInject();
 
     public abstract RemoteModInformation queryInformation() throws ModDirectorException;
+    public abstract void performInstall(Path targetFile, ProgressCallback progressCallback, ModDirector director,
+            RemoteModInformation information) throws ModDirectorException;
 
     public RemoteModMetadata getMetadata() {
         return metadata;
@@ -32,9 +42,12 @@ public abstract class ModDirectorRemoteMod {
     public Map<String, Object> getOptions() {
         return options;
     }
-
-	public String performInstall(Path targetFile, ProgressCallback progressCallback, ModDirector director,
-			RemoteModInformation information) throws ModDirectorException {
-		return null;
-	}
+    
+    public boolean forceInject() {
+	    return inject;
+    }
+	
+    public String folderName() {
+        return folderName;
+    }
 }

--- a/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/ModDirectorRemoteMod.java
+++ b/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/ModDirectorRemoteMod.java
@@ -14,15 +14,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public abstract class ModDirectorRemoteMod {
     private final RemoteModMetadata metadata;
     private final Map<String, Object> options;
-    private final String folderName;
-    private Boolean inject;
+    private final String folder;
+    private final boolean inject;
 
-    public ModDirectorRemoteMod(RemoteModMetadata metadata, Map<String, Object> options, String folderName, Boolean inject) {
+    public ModDirectorRemoteMod(RemoteModMetadata metadata, Map<String, Object> options, String folder, Boolean inject) {
         this.metadata = metadata;
         this.options = options == null ? Collections.emptyMap() : options;
-        this.folderName = folderName;
+        this.folder = folder;
         if(inject == null) {
-            this.inject = folderName == null;
+            this.inject = folder == null;
         } else {
             this.inject = inject;
         }
@@ -48,6 +48,6 @@ public abstract class ModDirectorRemoteMod {
     }
 	
     public String folderName() {
-        return folderName;
+        return folder;
     }
 }

--- a/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/ModDirectorRemoteMod.java
+++ b/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/ModDirectorRemoteMod.java
@@ -47,7 +47,7 @@ public abstract class ModDirectorRemoteMod {
 	    return inject;
     }
 	
-    public String folderName() {
+    public String getFolder() {
         return folder;
     }
 }

--- a/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/ModDirectorRemoteMod.java
+++ b/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/ModDirectorRemoteMod.java
@@ -1,5 +1,6 @@
 package net.jan.moddirector.core.configuration;
 
+import net.jan.moddirector.core.ModDirector;
 import net.jan.moddirector.core.exception.ModDirectorException;
 import net.jan.moddirector.core.manage.ProgressCallback;
 
@@ -19,8 +20,9 @@ public abstract class ModDirectorRemoteMod {
 
     public abstract String remoteType();
     public abstract String offlineName();
+    public abstract String folderName();
+	public abstract int forceInject();
 
-    public abstract void performInstall(Path targetFile, ProgressCallback progressCallback) throws ModDirectorException;
     public abstract RemoteModInformation queryInformation() throws ModDirectorException;
 
     public RemoteModMetadata getMetadata() {
@@ -30,4 +32,9 @@ public abstract class ModDirectorRemoteMod {
     public Map<String, Object> getOptions() {
         return options;
     }
+
+	public String performInstall(Path targetFile, ProgressCallback progressCallback, ModDirector director,
+			RemoteModInformation information) throws ModDirectorException {
+		return null;
+	}
 }

--- a/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/type/CurseRemoteMod.java
+++ b/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/type/CurseRemoteMod.java
@@ -59,9 +59,6 @@ public class CurseRemoteMod extends ModDirectorRemoteMod {
 
 	@Override
     public String performInstall(Path targetFile, ProgressCallback progressCallback, ModDirector director, RemoteModInformation information) throws ModDirectorException {
-		if (this.folderName != null) {
-        	targetFile = director.getPlatform().customFile(information.getTargetFilename(), this.folderName);
-        }
 		
 		try(WebGetResponse response = WebClient.get(this.information.downloadUrl)) {
             progressCallback.setSteps(1);

--- a/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/type/CurseRemoteMod.java
+++ b/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/type/CurseRemoteMod.java
@@ -35,10 +35,10 @@ public class CurseRemoteMod extends ModDirectorRemoteMod {
             @JsonProperty(value = "fileId", required = true) int fileId,
             @JsonProperty(value = "metadata") RemoteModMetadata metadata,
             @JsonProperty(value = "options") Map<String, Object> options,
-            @JsonProperty(value = "folder") String folderName,
+            @JsonProperty(value = "folder") String folder,
             @JsonProperty(value = "inject") Boolean inject
             ) {
-        super(metadata, options, folderName, inject);
+        super(metadata, options, folder, inject);
         this.addonId = addonId;
         this.fileId = fileId;
     }
@@ -53,7 +53,7 @@ public class CurseRemoteMod extends ModDirectorRemoteMod {
         return addonId + ":" + fileId;
     }
 
-	@Override
+    @Override
     public void performInstall(Path targetFile, ProgressCallback progressCallback, ModDirector director, RemoteModInformation information) throws ModDirectorException {
 
         try(WebGetResponse response = WebClient.get(this.information.downloadUrl)) {

--- a/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/type/CurseRemoteMod.java
+++ b/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/type/CurseRemoteMod.java
@@ -26,8 +26,6 @@ import java.util.Map;
 public class CurseRemoteMod extends ModDirectorRemoteMod {
     private final int addonId;
     private final int fileId;
-    private final String folderName;
-    private String inject;
 
     private CurseAddonFileInformation information;
 
@@ -38,13 +36,11 @@ public class CurseRemoteMod extends ModDirectorRemoteMod {
             @JsonProperty(value = "metadata") RemoteModMetadata metadata,
             @JsonProperty(value = "options") Map<String, Object> options,
             @JsonProperty(value = "folder") String folderName,
-            @JsonProperty(value = "inject") String inject
+            @JsonProperty(value = "inject") Boolean inject
             ) {
-        super(metadata, options);
+        super(metadata, options, folderName, inject);
         this.addonId = addonId;
         this.fileId = fileId;
-        this.folderName = folderName;
-        this.inject = inject;
     }
 
     @Override
@@ -58,17 +54,15 @@ public class CurseRemoteMod extends ModDirectorRemoteMod {
     }
 
 	@Override
-    public String performInstall(Path targetFile, ProgressCallback progressCallback, ModDirector director, RemoteModInformation information) throws ModDirectorException {
-		
-		try(WebGetResponse response = WebClient.get(this.information.downloadUrl)) {
+    public void performInstall(Path targetFile, ProgressCallback progressCallback, ModDirector director, RemoteModInformation information) throws ModDirectorException {
+
+        try(WebGetResponse response = WebClient.get(this.information.downloadUrl)) {
             progressCallback.setSteps(1);
             IOOperation.copy(response.getInputStream(), Files.newOutputStream(targetFile), progressCallback,
                     response.getStreamSize());
         } catch(IOException e) {
             throw new ModDirectorException("Failed to download file", e);
         }
-		
-		return this.folderName;
     }
 
     @Override
@@ -105,14 +99,4 @@ public class CurseRemoteMod extends ModDirectorRemoteMod {
         @JsonProperty
         private String[] gameVersion;
     }
-
-	@Override
-	public String folderName() {
-		return this.folderName;
-	}
-	
-	@Override
-	public int forceInject() {
-		return inject == null ? 0 : inject.equalsIgnoreCase("true") ? 1 : 2;
-	}
 }

--- a/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/type/UrlRemoteMod.java
+++ b/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/type/UrlRemoteMod.java
@@ -33,10 +33,10 @@ public class UrlRemoteMod extends ModDirectorRemoteMod {
             @JsonProperty(value = "follows") String[] follows,
             @JsonProperty(value = "metadata") RemoteModMetadata metadata,
             @JsonProperty(value = "options") Map<String, Object> options,
-            @JsonProperty(value = "folder") String folderName,
+            @JsonProperty(value = "folder") String folder,
             @JsonProperty(value = "inject") Boolean inject
     ) {
-    	super(metadata, options, folderName, inject);
+        super(metadata, options, folder, inject);
         this.fileName = fileName;
         this.url = url;
         this.follows = follows == null ? new String[0] : follows;

--- a/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/type/UrlRemoteMod.java
+++ b/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/type/UrlRemoteMod.java
@@ -59,10 +59,6 @@ public class UrlRemoteMod extends ModDirectorRemoteMod {
     @Override
     public String performInstall(Path targetFile, ProgressCallback progressCallback, ModDirector director, RemoteModInformation information) throws ModDirectorException {
         byte[] data = null;
-        
-        if (this.folderName != null) {
-        	targetFile = director.getPlatform().customFile(information.getTargetFilename(), this.folderName);
-        }
 
         progressCallback.setSteps(follows.length + 1);
 

--- a/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/type/UrlRemoteMod.java
+++ b/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/type/UrlRemoteMod.java
@@ -25,8 +25,6 @@ public class UrlRemoteMod extends ModDirectorRemoteMod {
     private final String fileName;
     private final URL url;
     private final String[] follows;
-    private final String folderName;
-    private String inject;
 
     @JsonCreator
     public UrlRemoteMod(
@@ -36,13 +34,11 @@ public class UrlRemoteMod extends ModDirectorRemoteMod {
             @JsonProperty(value = "metadata") RemoteModMetadata metadata,
             @JsonProperty(value = "options") Map<String, Object> options,
             @JsonProperty(value = "folder") String folderName,
-            @JsonProperty(value = "inject") String inject
+            @JsonProperty(value = "inject") Boolean inject
     ) {
-        super(metadata, options);
+    	super(metadata, options, folderName, inject);
         this.fileName = fileName;
-        this.folderName = folderName;
         this.url = url;
-        this.inject = inject;
         this.follows = follows == null ? new String[0] : follows;
     }
 
@@ -57,7 +53,7 @@ public class UrlRemoteMod extends ModDirectorRemoteMod {
     }
 
     @Override
-    public String performInstall(Path targetFile, ProgressCallback progressCallback, ModDirector director, RemoteModInformation information) throws ModDirectorException {
+    public void performInstall(Path targetFile, ProgressCallback progressCallback, ModDirector director, RemoteModInformation information) throws ModDirectorException {
         byte[] data = null;
 
         progressCallback.setSteps(follows.length + 1);
@@ -125,7 +121,6 @@ public class UrlRemoteMod extends ModDirectorRemoteMod {
         }
 
         progressCallback.done();
-        return this.folderName;
     }
 
     @Override
@@ -138,14 +133,4 @@ public class UrlRemoteMod extends ModDirectorRemoteMod {
             return new RemoteModInformation(name, name);
         }
     }
-
-	@Override
-	public String folderName() {
-		return this.folderName;
-	}
-	
-	@Override
-	public int forceInject() {
-		return inject == null ? 0 : inject.equalsIgnoreCase("true") ? 1 : 2;
-	}
 }

--- a/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/type/UrlRemoteMod.java
+++ b/mod-director-core/src/main/java/net/jan/moddirector/core/configuration/type/UrlRemoteMod.java
@@ -25,6 +25,8 @@ public class UrlRemoteMod extends ModDirectorRemoteMod {
     private final String fileName;
     private final URL url;
     private final String[] follows;
+    private final String folderName;
+    private String inject;
 
     @JsonCreator
     public UrlRemoteMod(
@@ -32,11 +34,15 @@ public class UrlRemoteMod extends ModDirectorRemoteMod {
             @JsonProperty(value = "url", required = true) URL url,
             @JsonProperty(value = "follows") String[] follows,
             @JsonProperty(value = "metadata") RemoteModMetadata metadata,
-            @JsonProperty(value = "options") Map<String, Object> options
+            @JsonProperty(value = "options") Map<String, Object> options,
+            @JsonProperty(value = "folder") String folderName,
+            @JsonProperty(value = "inject") String inject
     ) {
         super(metadata, options);
         this.fileName = fileName;
+        this.folderName = folderName;
         this.url = url;
+        this.inject = inject;
         this.follows = follows == null ? new String[0] : follows;
     }
 
@@ -51,8 +57,12 @@ public class UrlRemoteMod extends ModDirectorRemoteMod {
     }
 
     @Override
-    public void performInstall(Path targetFile, ProgressCallback progressCallback) throws ModDirectorException {
+    public String performInstall(Path targetFile, ProgressCallback progressCallback, ModDirector director, RemoteModInformation information) throws ModDirectorException {
         byte[] data = null;
+        
+        if (this.folderName != null) {
+        	targetFile = director.getPlatform().customFile(information.getTargetFilename(), this.folderName);
+        }
 
         progressCallback.setSteps(follows.length + 1);
 
@@ -119,6 +129,7 @@ public class UrlRemoteMod extends ModDirectorRemoteMod {
         }
 
         progressCallback.done();
+        return this.folderName;
     }
 
     @Override
@@ -131,4 +142,14 @@ public class UrlRemoteMod extends ModDirectorRemoteMod {
             return new RemoteModInformation(name, name);
         }
     }
+
+	@Override
+	public String folderName() {
+		return this.folderName;
+	}
+	
+	@Override
+	public int forceInject() {
+		return inject == null ? 0 : inject.equalsIgnoreCase("true") ? 1 : 2;
+	}
 }

--- a/mod-director-core/src/main/java/net/jan/moddirector/core/manage/InstallController.java
+++ b/mod-director-core/src/main/java/net/jan/moddirector/core/manage/InstallController.java
@@ -46,7 +46,9 @@ public class InstallController {
 
         callback.title(information.getDisplayName());
 
-        Path targetFile = director.getPlatform().modFile(information.getTargetFilename());
+        Path targetFile = mod.folderName() == null ? director.getPlatform().modFile(information.getTargetFilename()) 
+        		: mod.folderName().equalsIgnoreCase(".") ? director.getPlatform().rootFile(information.getTargetFilename()) 
+        				: director.getPlatform().customFile(information.getTargetFilename(), mod.folderName());
 
         if(mod.getMetadata() != null && Files.isRegularFile(targetFile)) {
             HashResult hashResult = mod.getMetadata().checkHashes(targetFile, director);
@@ -90,7 +92,7 @@ public class InstallController {
         }
 
         try {
-            mod.performInstall(targetFile, callback);
+        	mod.performInstall(targetFile, callback, director, information);
         } catch(ModDirectorException e) {
             director.getLogger().logThrowable(ModDirectorSeverityLevel.ERROR, "ModDirector/InstallController",
                     "CORE", e, "Failed to install mod %s", mod.offlineName());
@@ -108,7 +110,7 @@ public class InstallController {
         } else {
             director.getLogger().log(ModDirectorSeverityLevel.INFO, "ModDirector/InstallController",
                     "CORE", "Installed mod file %s", targetFile.toString());
-            director.installSuccess(new InstalledMod(targetFile, mod.getOptions()));
+            director.installSuccess(new InstalledMod(targetFile, mod.getOptions(), mod.forceInject()));
         }
 
         callback.done();

--- a/mod-director-core/src/main/java/net/jan/moddirector/core/manage/InstallController.java
+++ b/mod-director-core/src/main/java/net/jan/moddirector/core/manage/InstallController.java
@@ -47,8 +47,8 @@ public class InstallController {
         callback.title(information.getDisplayName());
 
         Path targetFile = mod.folderName() == null ? director.getPlatform().modFile(information.getTargetFilename()) 
-        		: mod.folderName().equalsIgnoreCase(".") ? director.getPlatform().rootFile(information.getTargetFilename()) 
-        				: director.getPlatform().customFile(information.getTargetFilename(), mod.folderName());
+            : mod.folderName().equalsIgnoreCase(".") ? director.getPlatform().rootFile(information.getTargetFilename()) 
+                : director.getPlatform().customFile(information.getTargetFilename(), mod.folderName());
 
         if(mod.getMetadata() != null && Files.isRegularFile(targetFile)) {
             HashResult hashResult = mod.getMetadata().checkHashes(targetFile, director);
@@ -92,7 +92,7 @@ public class InstallController {
         }
 
         try {
-        	mod.performInstall(targetFile, callback, director, information);
+            mod.performInstall(targetFile, callback, director, information);
         } catch(ModDirectorException e) {
             director.getLogger().logThrowable(ModDirectorSeverityLevel.ERROR, "ModDirector/InstallController",
                     "CORE", e, "Failed to install mod %s", mod.offlineName());

--- a/mod-director-core/src/main/java/net/jan/moddirector/core/manage/InstallController.java
+++ b/mod-director-core/src/main/java/net/jan/moddirector/core/manage/InstallController.java
@@ -46,9 +46,9 @@ public class InstallController {
 
         callback.title(information.getDisplayName());
 
-        Path targetFile = mod.folderName() == null ? director.getPlatform().modFile(information.getTargetFilename()) 
-            : mod.folderName().equalsIgnoreCase(".") ? director.getPlatform().rootFile(information.getTargetFilename()) 
-                : director.getPlatform().customFile(information.getTargetFilename(), mod.folderName());
+        Path targetFile = mod.getFolder() == null ? director.getPlatform().modFile(information.getTargetFilename()) 
+            : mod.getFolder().equalsIgnoreCase(".") ? director.getPlatform().rootFile(information.getTargetFilename()) 
+                : director.getPlatform().customFile(information.getTargetFilename(), mod.getFolder());
 
         if(mod.getMetadata() != null && Files.isRegularFile(targetFile)) {
             HashResult hashResult = mod.getMetadata().checkHashes(targetFile, director);

--- a/mod-director-core/src/main/java/net/jan/moddirector/core/manage/InstalledMod.java
+++ b/mod-director-core/src/main/java/net/jan/moddirector/core/manage/InstalledMod.java
@@ -18,7 +18,7 @@ public class InstalledMod {
         return file;
     }
 
-    public boolean getInject() {
+    public boolean shouldInject() {
         return inject;
     }
     

--- a/mod-director-core/src/main/java/net/jan/moddirector/core/manage/InstalledMod.java
+++ b/mod-director-core/src/main/java/net/jan/moddirector/core/manage/InstalledMod.java
@@ -5,10 +5,10 @@ import java.util.Map;
 
 public class InstalledMod {
     private final Path file;
-    private final int inject;
+    private final boolean inject;
     private final Map<String, Object> options;
 
-    public InstalledMod(Path file, Map<String, Object> options, int inject) {
+    public InstalledMod(Path file, Map<String, Object> options, boolean inject) {
         this.file = file;
         this.inject = inject;
         this.options = options;
@@ -18,7 +18,7 @@ public class InstalledMod {
         return file;
     }
 
-    public int getInject() {
+    public boolean getInject() {
         return inject;
     }
     

--- a/mod-director-core/src/main/java/net/jan/moddirector/core/manage/InstalledMod.java
+++ b/mod-director-core/src/main/java/net/jan/moddirector/core/manage/InstalledMod.java
@@ -5,10 +5,12 @@ import java.util.Map;
 
 public class InstalledMod {
     private final Path file;
+    private final int inject;
     private final Map<String, Object> options;
 
-    public InstalledMod(Path file, Map<String, Object> options) {
+    public InstalledMod(Path file, Map<String, Object> options, int inject) {
         this.file = file;
+        this.inject = inject;
         this.options = options;
     }
 
@@ -16,6 +18,10 @@ public class InstalledMod {
         return file;
     }
 
+    public int getInject() {
+        return inject;
+    }
+    
     public Map<String, Object> getOptions() {
         return options;
     }

--- a/mod-director-core/src/main/java/net/jan/moddirector/core/platform/ModDirectorPlatform.java
+++ b/mod-director-core/src/main/java/net/jan/moddirector/core/platform/ModDirectorPlatform.java
@@ -8,6 +8,8 @@ public interface ModDirectorPlatform {
     String name();
     Path configurationDirectory();
     Path modFile(String modFileName);
+	Path rootFile(String modFileName);
+	Path customFile(String modFileName, String modFolderName);
     ModDirectorLogger logger();
     PlatformSide side();
 

--- a/mod-director-core/src/main/java/net/jan/moddirector/core/platform/ModDirectorPlatform.java
+++ b/mod-director-core/src/main/java/net/jan/moddirector/core/platform/ModDirectorPlatform.java
@@ -8,8 +8,8 @@ public interface ModDirectorPlatform {
     String name();
     Path configurationDirectory();
     Path modFile(String modFileName);
-	Path rootFile(String modFileName);
-	Path customFile(String modFileName, String modFolderName);
+    Path rootFile(String modFileName);
+    Path customFile(String modFileName, String modFolderName);
     ModDirectorLogger logger();
     PlatformSide side();
 

--- a/mod-director-launchwrapper/src/main/java/net/jan/moddirector/launchwrapper/LaunchwrapperModDirectorPlatform.java
+++ b/mod-director-launchwrapper/src/main/java/net/jan/moddirector/launchwrapper/LaunchwrapperModDirectorPlatform.java
@@ -40,6 +40,16 @@ public class LaunchwrapperModDirectorPlatform implements ModDirectorPlatform {
     public Path modFile(String modFileName) {
         return tweaker.getGameDir().toPath().resolve("mods").resolve(modFileName);
     }
+    
+    @Override
+    public Path customFile(String modFileName, String modFolderName) {
+        return tweaker.getGameDir().toPath().resolve(modFolderName).resolve(modFileName);
+    }
+    
+    @Override
+    public Path rootFile(String modFileName) {
+        return tweaker.getGameDir().toPath().resolve(modFileName);
+    }
 
     @Override
     public ModDirectorLogger logger() {

--- a/mod-director-launchwrapper/src/main/java/net/jan/moddirector/launchwrapper/forge/ForgeLateLoader.java
+++ b/mod-director-launchwrapper/src/main/java/net/jan/moddirector/launchwrapper/forge/ForgeLateLoader.java
@@ -335,6 +335,17 @@ public class ForgeLateLoader {
 
     private void handle(InstalledMod mod) {
         Path injectedFile = mod.getFile();
+        
+        switch(mod.getInject()) {
+	        case 1:
+	        	break;
+	        case 2:
+	        	return;
+	        case 0:
+	        default:
+	            if (!mod.getFile().toString().contains("mods")) return;
+	            break;
+        }
 
         reflectiveIgnoredMods.remove(injectedFile.toFile().getName());
 

--- a/mod-director-launchwrapper/src/main/java/net/jan/moddirector/launchwrapper/forge/ForgeLateLoader.java
+++ b/mod-director-launchwrapper/src/main/java/net/jan/moddirector/launchwrapper/forge/ForgeLateLoader.java
@@ -336,7 +336,7 @@ public class ForgeLateLoader {
     private void handle(InstalledMod mod) {
         Path injectedFile = mod.getFile();
         
-        if(!mod.getInject()) {
+        if(!mod.shouldInject()) {
             return;
         }
 

--- a/mod-director-launchwrapper/src/main/java/net/jan/moddirector/launchwrapper/forge/ForgeLateLoader.java
+++ b/mod-director-launchwrapper/src/main/java/net/jan/moddirector/launchwrapper/forge/ForgeLateLoader.java
@@ -336,15 +336,8 @@ public class ForgeLateLoader {
     private void handle(InstalledMod mod) {
         Path injectedFile = mod.getFile();
         
-        switch(mod.getInject()) {
-	        case 1:
-	        	break;
-	        case 2:
-	        	return;
-	        case 0:
-	        default:
-	            if (!mod.getFile().toString().contains("mods")) return;
-	            break;
+        if(!mod.getInject()) {
+            return;
         }
 
         reflectiveIgnoredMods.remove(injectedFile.toFile().getName());

--- a/mod-director-standalone/src/main/java/net/jan/moddirector/standalone/ModDirectorStandalonePlatform.java
+++ b/mod-director-standalone/src/main/java/net/jan/moddirector/standalone/ModDirectorStandalonePlatform.java
@@ -47,4 +47,14 @@ public class ModDirectorStandalonePlatform implements ModDirectorPlatform {
     public boolean headless() {
         return false;
     }
+
+    @Override
+    public Path customFile(String modFileName, String modFolderName) {
+        return Paths.get(".", modFolderName).resolve(modFileName);
+    }
+
+    @Override
+    public Path rootFile(String modFileName) {
+        return Paths.get(".", modFileName);
+    }
 }


### PR DESCRIPTION
The changes essentially boil down to the following:
- you can specify a folder to download to (both curseforge mods and url mods) using "folder": "name" e.g. "folder": "resourcepacks" will download it to resourcepacks. "folder": "." is what you would use if you wanted to download something directly into the .minecraft folder.
- you can specify if ModDirector will try to inject a mod. If it is "inject": "false", moddirector will not try to inject it no matter what. Useful for mods like that one that allows you to add custom items that required mozilla JS files inside the mods directory. "inject": "true" will try to inject no matter what (note: if the mod is not located inside the mods folder, forge will ignore it anyway). Omitting the line will default to the following behavior: Try inject if inside mods folder, don't try inject if outside mods folder.